### PR TITLE
Fix search bar when entering regex characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1307,7 +1307,8 @@ Lifestyle Recommendations:
         searchInput.addEventListener('input', () => {
             const query = searchInput.value.trim();
             if (query.length < 3) { searchResultsContainer.innerHTML = ''; searchResultsContainer.classList.add('hidden'); return; }
-            const regex = new RegExp(query, 'gi');
+            const escapedQuery = query.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+            const regex = new RegExp(escapedQuery, 'gi');
             const results = []; let match;
             while ((match = regex.exec(reportText)) !== null) {
                 const startIndex = Math.max(0, match.index - 50);


### PR DESCRIPTION
## Summary
- Escape user input before building search regex to keep the search bar working even with special characters

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894b72cf0a48328ad44596082e7a54c